### PR TITLE
Make all packages compile with ghc-8.2

### DIFF
--- a/yarr-benchmarking/yarr-benchmarking.cabal
+++ b/yarr-benchmarking/yarr-benchmarking.cabal
@@ -22,7 +22,7 @@ source-repository head
 
 Library
     build-depends:
-        base >= 4.6 && <4.9,
+        base >= 4.6 && <4.11,
         yarr >= 1.3,
         old-time == 1.1.*,
         rdtsc == 1.3.*

--- a/yarr-image-io/yarr-image-io.cabal
+++ b/yarr-image-io/yarr-image-io.cabal
@@ -23,7 +23,7 @@ source-repository head
 
 Library
     build-depends:
-        base >= 4.6 && <4.9,
+        base >= 4.6 && <4.11,
         yarr >= 1.3
 
     extra-libraries: IL

--- a/yarr/Data/Yarr/Utils/FixedVector.hs
+++ b/yarr/Data/Yarr/Utils/FixedVector.hs
@@ -50,6 +50,7 @@ import Data.Yarr.Utils.FixedVector.VecTuple
 import Data.Yarr.Utils.FixedVector.VecTupleInstances
 
 import Data.Yarr.Utils.FixedVector.InlinableArity
+import Data.Yarr.Utils.FixedVector.InlinableArityInstances
 
 
 vl_1 :: a -> VecList N1 a

--- a/yarr/Data/Yarr/Utils/FixedVector/VecTuple.hs
+++ b/yarr/Data/Yarr/Utils/FixedVector/VecTuple.hs
@@ -17,7 +17,11 @@ funD' name cs =
         inline = pragInlD name Inline ConLike AllPhases
     in [fd, inline]
 
-#if MIN_VERSION_template_haskell(2,11,0)
+#if MIN_VERSION_template_haskell(2,12,0)
+newtypeInstD' ctxt tc tys con derivs =
+    let kindSig = Nothing
+    in newtypeInstD ctxt tc tys kindSig con derivs
+#elif MIN_VERSION_template_haskell(2,11,0)
 newtypeInstD' ctxt tc tys con derivs =
     let kindSig = Nothing
     in newtypeInstD ctxt tc tys kindSig con (cxt derivs)

--- a/yarr/yarr.cabal
+++ b/yarr/yarr.cabal
@@ -44,12 +44,12 @@ source-repository head
 
 Library
     build-depends:
-        base             >= 4.6 && < 4.10,
+        base             >= 4.6 && < 4.11,
         ghc-prim         >= 0.3 && < 0.6,
         deepseq          >= 1.3 && < 1.5,
         fixed-vector     >= 0.8 && < 0.9,
         primitive        >= 0.6 && < 0.7,
-        template-haskell >= 2.8 && < 2.12,
+        template-haskell >= 2.8 && < 2.13,
         missing-foreign  == 0.1.1
 
     extensions:


### PR DESCRIPTION
* increased upper bound for base on yarr, yarr-image-io,
  yarr-benchmarking to base < 4.11
* increased upper bound for template-haskell < 2.13 Fix compilation error
* Bring back orphan instances for `InlinableArity` to scope.